### PR TITLE
Removed hardcoded -i (runInBand) flag from jest. 

### DIFF
--- a/jest/runner.sh.tpl
+++ b/jest/runner.sh.tpl
@@ -54,7 +54,6 @@ export NODE_OPTIONS="${NODE_OPTIONS-} --experimental-specifier-resolution=node"
   --preserve-symlinks-main \
   %{node_options} \
   "$(abspath "$RUNFILES_DIR"/%{main_module})" \
-  -i \
   --config="$RUNFILES_DIR"/%{config_loader} \
   --no-cache \
   --no-watchman \


### PR DESCRIPTION
This allows consuming repos to control whether Jest runs tests sequentially or in parallel.