### PR TITLE
Add yarn_install rule for simpler node_modules setup

### DIFF
--- a/npm/BUILD.bazel
+++ b/npm/BUILD.bazel
@@ -10,6 +10,7 @@ exports_files(
     [
         "npm-publish.sh.tpl",
         "yarn-audit-runner.sh.tpl",
+        "yarn-install-runner.sh.tpl",
         "yarn-resolve.sh.tpl",
     ],
     visibility = ["//visibility:public"],

--- a/npm/yarn-install-runner.sh.tpl
+++ b/npm/yarn-install-runner.sh.tpl
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -z "${RUNFILES_DIR-}" ]; then
+  if [ ! -z "${RUNFILES_MANIFEST_FILE-}" ]; then
+    export RUNFILES_DIR="${RUNFILES_MANIFEST_FILE%.runfiles_manifest}.runfiles"
+  else
+    export RUNFILES_DIR="$0.runfiles"
+  fi
+fi
+
+path=%{path}
+cd "${BUILD_WORKSPACE_DIRECTORY:-.}${path:+/$path}"
+
+exec "$RUNFILES_DIR"/%{yarn} install "$@"


### PR DESCRIPTION
## Summary

- Adds a new `yarn_install` rule that runs `yarn install` using the Bazel-managed yarn binary
- Provides a simpler alternative to `nodejs_install`'s manifest-based approach
- More reliable for tools like Vite that expect a standard `node_modules` layout with a fully populated `.bin` directory