### PR TITLE
Typescript trace option

### DIFF
--- a/typescript/BUILD.bazel
+++ b/typescript/BUILD.bazel
@@ -1,7 +1,14 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 load("@rules_javascript//commonjs:rules.bzl", "cjs_root")
 load("@rules_javascript//nodejs:rules.bzl", "nodejs_binary")
 load("//javascript:rules.bzl", "js_library")
+
+bool_flag(
+    name = "trace",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
 
 exports_files(
     glob(["**/*.bzl"]),

--- a/typescript/config/dist/bundle.js
+++ b/typescript/config/dist/bundle.js
@@ -79,13 +79,17 @@ parser.add_argument("output");
         tsconfig.compilerOptions.module = args.module;
         // should allow choices, but it's so complicated
         switch (args.module.toLowerCase()) {
+            case "bundler":
             case "es2015":
             case "es2020":
             case "es2022": {
                 tsconfig.compilerOptions.moduleResolution = "bundler";
                 break;
             }
-            case "node20": {
+            case "node16":
+            case "node18":
+            case "node20":
+            case "nodenext": {
                 tsconfig.compilerOptions.moduleResolution = "nodenext";
                 break;
             }


### PR DESCRIPTION
I've been working on a typescript profiling tool in my spare time, and this gives me the ability to add `--generateTrace` to bazel type checking commands.

Tested and working btw, locally I am pointing the main repo to this branch and it does what I want