### PR TITLE
typescript: emit lint-only tsconfig in native mode (no preserveSymlinks)

### DIFF
--- a/typescript-eslint/rules.bzl
+++ b/typescript-eslint/rules.bzl
@@ -116,9 +116,13 @@ def _ts_eslint_format_impl(ctx):
     args.add("--manifest", ts_compile.manifest)
     for file_def in file_defs.values():
         args.add("%s=%s" % (file_def.src.path, file_def.generated.path))
+    # Prefer the lint-only tsconfig (no preserveSymlinks=true) when the
+    # compile rule emitted one. Falls back to the compile tsconfig for
+    # legacy (non-native) consumers that don't set lint_config_path.
+    ts_config_path = ts_compile.lint_config_path if hasattr(ts_compile, "lint_config_path") and ts_compile.lint_config_path else ts_compile.config_path
     actions.run(
         arguments = [args],
-        env = {"TSESTREE_SINGLE_RUN": "true", "TS_CONFIG": ts_compile.config_path},
+        env = {"TSESTREE_SINGLE_RUN": "true", "TS_CONFIG": ts_config_path},
         executable = ts_eslint.bin.executable,
         inputs = depset(
             [ts_compile.manifest],

--- a/typescript/config/dist/bundle.js
+++ b/typescript/config/dist/bundle.js
@@ -3,7 +3,6 @@
 var argparse = require('argparse');
 var promises = require('node:fs/promises');
 var node_path = require('node:path');
-var node_fs = require('node:fs');
 
 /**
  * Faster version of "append" action.
@@ -51,6 +50,11 @@ parser.add_argument("--type-root", {
     default: [],
 });
 parser.add_argument("--package-manifest", { dest: "packageManifest" });
+parser.add_argument("--no-preserve-symlinks", {
+    action: "store_true",
+    default: false,
+    dest: "noPreserveSymlinks",
+});
 parser.add_argument("output");
 (async () => {
     const args = parser.parse_args();
@@ -76,12 +80,18 @@ parser.add_argument("output");
     if (args.typeRoots.length > 0) {
         tsconfig.compilerOptions.typeRoots = args.typeRoots.map(relativePath);
     }
-    // preserveSymlinks is critical in native mode (--package-manifest):
-    // the runtime stager creates real node_modules/ symlinks from the
-    // manifest; without preserveSymlinks, tsc/tsgo may resolve through
-    // symlinks to duplicate nominal type identities and emit TS2322
-    // errors where none exist.
-    if (args.packageManifest) {
+    // preserveSymlinks is critical for the native (tsgo) compile path
+    // (--package-manifest): the runtime stager creates real node_modules/
+    // symlinks from the manifest; without preserveSymlinks, tsc/tsgo may
+    // resolve through symlinks to duplicate nominal type identities and
+    // emit TS2322 errors where none exist.
+    //
+    // It is NOT safe for the lint path. The lint binary uses the
+    // fs-linker per-package nested VFS; with preserveSymlinks=true, the
+    // resolver walks every nested-symlink chain and accumulates a
+    // quadratic miss-cache that exhausts the heap on large packages.
+    // Callers that emit a lint-specific tsconfig pass --no-preserve-symlinks.
+    if (args.packageManifest && !args.noPreserveSymlinks) {
         tsconfig.compilerOptions.preserveSymlinks = true;
     }
     if (args.rootDirs) {
@@ -125,13 +135,15 @@ parser.add_argument("output");
     if (args.target) {
         tsconfig.compilerOptions.target = args.target;
     }
-    // With the preload stager producing a real node_modules/ tree at the Bazel
-    // sandbox root, tsc's own module resolution handles everything: imports via
-    // package "exports", ambient /// <reference types>, tsconfig "extends", and
-    // @types/X -> X pairing. We intentionally do NOT emit compilerOptions.paths
-    // or explicit ambient files here, because that would give tsc a second way
-    // to reach the same dep file and produce "type X is not assignable to type
-    // X" errors from duplicate nominal identities.
+    // NOTE: --package-manifest is passed by rules.bzl in native mode as a
+    // signal that tsc/tsgo will see a real node_modules/ tree staged by
+    // the _STAGE_NM_JS runtime stager. We intentionally do NOT emit
+    // compilerOptions.paths or explicit ambient files here — doing so
+    // would give tsc a second way to reach the same dep file and produce
+    // "type X is not assignable to type X" errors from duplicate nominal
+    // identities. The manifest path is intentionally unused by this tool;
+    // it's declared as an input to the config action so the action cache
+    // key depends on the dep graph.
     void args.packageManifest;
     const content = JSON.stringify(tsconfig);
     await promises.writeFile(args.output, content, "utf8");

--- a/typescript/config/src/main.ts
+++ b/typescript/config/src/main.ts
@@ -30,6 +30,11 @@ parser.add_argument("--type-root", {
   default: [],
 });
 parser.add_argument("--package-manifest", { dest: "packageManifest" });
+parser.add_argument("--no-preserve-symlinks", {
+  action: "store_true",
+  default: false,
+  dest: "noPreserveSymlinks",
+});
 parser.add_argument("output");
 
 interface Args {
@@ -45,6 +50,7 @@ interface Args {
   target?: string;
   typeRoots: string[];
   packageManifest?: string;
+  noPreserveSymlinks: boolean;
   output: string;
 }
 
@@ -74,12 +80,18 @@ interface Args {
   if (args.typeRoots.length > 0) {
     tsconfig.compilerOptions.typeRoots = args.typeRoots.map(relativePath);
   }
-  // preserveSymlinks is critical in native mode (--package-manifest): the
-  // runtime stager creates real node_modules/ symlinks from the manifest;
-  // without preserveSymlinks, tsc/tsgo may resolve through symlinks to
-  // duplicate nominal type identities and emit TS2322 errors where none
-  // exist.
-  if (args.packageManifest) {
+  // preserveSymlinks is critical for the native (tsgo) compile path
+  // (--package-manifest): the runtime stager creates real node_modules/
+  // symlinks from the manifest; without preserveSymlinks, tsc/tsgo may
+  // resolve through symlinks to duplicate nominal type identities and
+  // emit TS2322 errors where none exist.
+  //
+  // It is NOT safe for the lint path. The lint binary uses the
+  // fs-linker per-package nested VFS; with preserveSymlinks=true, the
+  // resolver walks every nested-symlink chain and accumulates a
+  // quadratic miss-cache that exhausts the heap on large packages.
+  // Callers that emit a lint-specific tsconfig pass --no-preserve-symlinks.
+  if (args.packageManifest && !args.noPreserveSymlinks) {
     tsconfig.compilerOptions.preserveSymlinks = true;
   }
   if (args.rootDirs) {

--- a/typescript/providers.bzl
+++ b/typescript/providers.bzl
@@ -29,6 +29,7 @@ TsCompileInfo = provider(
         "config_path": "Configuration path",
         "configs": "Depset of config files",
         "declarations": "Depset of upstream declarations",
+        "lint_config_path": "Lint-only configuration path. Set in native (--package-manifest) mode to a tsconfig variant without preserveSymlinks=true so typescript-eslint, running inside the fs-linker per-package VFS, does not OOM walking nested-symlink resolver chains. Falls back to config_path when unset.",
         "manifest": "Manifest file",
         "srcs": "Depset of sources",
         "runtime_js": "Runtime files",

--- a/typescript/rules.bzl
+++ b/typescript/rules.bzl
@@ -342,6 +342,34 @@ def _ts_library_impl(ctx):
         outputs = [tsconfig],
     )
 
+    # In native (tsgo) mode, also emit a lint-only tsconfig variant
+    # without preserveSymlinks=true. tsgo compile needs preserveSymlinks
+    # to keep nominal type identities stable through stage-nm symlinks,
+    # but typescript-eslint inside the fs-linker per-package VFS OOMs
+    # with that flag set (resolver walks nested-symlink chains).
+    lint_tsconfig = None
+    if compiler.native:
+        lint_tsconfig = actions.declare_file("%s.lint-tsconfig.json" % ctx.attr.name)
+        lint_args = actions.args()
+        if tsconfig_path:
+            lint_args.add("--config", "%s/%s" % (tsconfig_dep.package.path, tsconfig_path))
+        lint_args.add("--declaration-dir", "%s/%s" % (output_.path, declaration_prefix) if declaration_prefix else output_.path)
+        lint_args.add("--module", module_)
+        lint_args.add("--root-dir", "%s/%s" % (output_.path, strip_prefix) if strip_prefix else output_.path)
+        lint_args.add("--root-dirs", "%s/%s" % (output_.path, strip_prefix) if strip_prefix else output_.path)
+        lint_args.add("--root-dirs", "%s/%s" % (output_.path, declaration_prefix) if declaration_prefix else output_.path)
+        lint_args.add("--target", target_)
+        lint_args.add("--package-manifest", package_manifest.path)
+        lint_args.add("--no-preserve-symlinks")
+        lint_args.add(lint_tsconfig)
+        actions.run(
+            arguments = [lint_args, args_file],
+            executable = config.files_to_run.executable,
+            inputs = tsconfig_inputs,
+            tools = [config.files_to_run],
+            outputs = [lint_tsconfig],
+        )
+
     # compile declarations
     if outputs:
         trace_args = []
@@ -427,11 +455,13 @@ def _ts_library_impl(ctx):
         files = js,
     )
 
+    config_files = [tsconfig] + ([lint_tsconfig] if lint_tsconfig else [])
     ts_compile_info = TsCompileInfo(
         compiler = compiler.bin,
         config_path = tsconfig.path,
-        configs = depset([tsconfig], transitive = tsconfig_js and [tsconfig_js.transitive_files]),
+        configs = depset(config_files, transitive = tsconfig_js and [tsconfig_js.transitive_files]),
         declarations = depset(transitive = [dep.transitive_files for dep in ts_deps]),
+        lint_config_path = lint_tsconfig.path if lint_tsconfig else None,
         manifest = package_manifest,
         runtime_js = depset(transitive = [js_info.transitive_files for js_info in compiler.runtime_js]),
         srcs = depset(inputs),


### PR DESCRIPTION
## Summary

Native (tsgo) compile needs `compilerOptions.preserveSymlinks=true` to keep nominal type identities stable through stage-nm's flat-FS symlinks (without it, tsgo emits TS1360/TS2322 errors on Zod-style transitive types).

The lint binary in `typescript-eslint/linter` runs node typescript-eslint inside fs-linker's per-package nested VFS. With the same `preserveSymlinks=true`, TypeScript's resolver walks every nested-symlink chain looking for transitive deps and accumulates a quadratic miss-cache that exhausts V8's heap on large packages.

This PR splits the tsconfig so each tool gets the flag it needs:

- `typescript/config` gets a `--no-preserve-symlinks` flag.
- `typescript/rules.bzl` emits a second tsconfig action in native mode (`*.lint-tsconfig.json`) with that flag set.
- `TsCompileInfo` gains `lint_config_path`, populated only in native mode (legacy tsc path keeps preserveSymlinks default and needs no variant).
- `typescript-eslint/rules.bzl` prefers `lint_config_path` when present, with a fallback to `config_path` for legacy consumers.

Compile is unchanged.

## Verification (downstream redo monorepo)

- 6 OOM-prone lint targets at 8 GiB heap, native mode: previously hit V8 OOM at ~150 s, now pass.
- `redo/server-models`: 152 s OOM → ~40 s clean pass.
- Lint output diff against a legacy-tsc baseline: 186 .patch files in each, **0 content differences** (`diff -r`). No silent coverage loss.
- All 6 targets (`server-models`, `merchant/server`, `merchant/app`, `temporal/implementations`, `effect-api/services`, `mcp`) pass end-to-end via `local_path_override`.

## Test plan

- [x] Smoke build: `bazel build //typescript-eslint/linter:lib //typescript/config:bin //typescript:rules.bzl`
- [x] Bundle regenerated via `bazel run //typescript/config:gen`
- [x] End-to-end downstream: 6 OOM-prone lint targets pass at 8 GiB heap in native mode
- [x] Byte-identical lint output vs legacy tsc baseline on `redo/server-models`
- [ ] Add an upstream test target exercising the lint variant emission (follow-up if desired)

🤖 Generated with [Claude Code](https://claude.com/claude-code)