### PR TITLE
webpack_server: regenerate the package manifest PnP removed

### DIFF
--- a/nodejs/rules.bzl
+++ b/nodejs/rules.bzl
@@ -260,7 +260,11 @@ def _nodejs_binary_impl(ctx):
         runfiles = runfiles,
     )
 
-    return [default_info]
+    # PnP resolves this binary's modules without materializing node_modules, so
+    # a filesystem view of the package tree no longer exists. Forward the
+    # CommonJS graph -- in the binary's own configuration -- for rules that
+    # still need one, such as webpack_server.
+    return [default_info] + ([cjs_dep] if cjs_dep else [])
 
 def _nodejs_transition_impl(settings, attrs):
     return {"//javascript:module": "node"}

--- a/webpack/providers.bzl
+++ b/webpack/providers.bzl
@@ -3,6 +3,7 @@ WebpackInfo = provider(
     fields = {
         "bin": "Webpack executable",
         "server": "Webpack server executable",
+        "server_cjs": "Webpack server CommonJS packages",
         "client_cjs": "Webpack dev server lib",
         "client_js": "Webpack dev server lib",
         "config_path": "Config path",

--- a/webpack/rules.bzl
+++ b/webpack/rules.bzl
@@ -39,6 +39,7 @@ def _webpack_impl(ctx):
     config = ctx.attr.config
     config_dep = ctx.attr.config_dep[CjsInfo]
     server = ctx.attr.server[DefaultInfo]
+    server_cjs = ctx.attr.server[CjsInfo]
 
     webpack_info = WebpackInfo(
         bin = bin,
@@ -46,6 +47,7 @@ def _webpack_impl(ctx):
         client_js = client_js,
         config_path = "%s/%s" % (to_rlocation_path(ctx, config_dep.package), config),
         server = server,
+        server_cjs = server_cjs,
     )
 
     return [webpack_info]
@@ -76,6 +78,7 @@ webpack = rule(
             cfg = "exec",
             executable = True,
             mandatory = True,
+            providers = [CjsInfo],
         ),
         "client": attr.label_list(
             mandatory = True,
@@ -270,6 +273,7 @@ def _webpack_server_impl(ctx):
     source_map = ctx.attr._source_map[BuildSettingInfo].value
     webpack = ctx.split_attr.webpack["tool"][WebpackInfo]
     webpack_client = ctx.split_attr.webpack["browser"][WebpackInfo]
+    server_cjs = webpack.server_cjs
     dep_js = ctx.attr.dep[0][JsInfo]
     dep_cjs = ctx.attr.dep[0][CjsInfo]
     name = ctx.attr.name
@@ -299,6 +303,23 @@ def _webpack_server_impl(ctx):
         package_path = package_path,
     )
 
+    def node_package_path(package):
+        return to_rlocation_path(rlocation_ctx, package)
+
+    # The webpack tools resolve their own modules through PnP, but the dev
+    # server bundles files out of that tree -- webpack's hot client and the
+    # entries plugins inject -- and webpack resolves those from the filesystem.
+    # The shim links the tree back in from this manifest.
+    node_package_manifest = actions.declare_file("%s-node-packages.json" % name)
+    gen_manifest(
+        actions = actions,
+        manifest_bin = ctx.attr._manifest[DefaultInfo],
+        manifest = node_package_manifest,
+        packages = server_cjs.transitive_packages,
+        deps = server_cjs.transitive_links,
+        package_path = node_package_path,
+    )
+
     js_info = JsInfo(
         transitive_files = depset(transitive = [js_info.transitive_files for js_info in [dep_js] + webpack_client.client_js]),
     )
@@ -320,6 +341,7 @@ def _webpack_server_impl(ctx):
             "%{digest}": shell.quote(to_rlocation_path(ctx, src_digest)),
             "%{input_root}": shell.quote(package_path(dep_cjs.package)),
             "%{js_source_map}": shell.quote(json.encode(source_map)),
+            "%{node_package_manifest}": shell.quote(to_rlocation_path(ctx, node_package_manifest)),
             "%{package_manifest}": shell.quote(to_rlocation_path(ctx, package_manifest)),
             "%{runtime}": shell.quote(to_rlocation_path(ctx, runtime)),
             "%{shim}": shell.quote(to_rlocation_path(ctx, shim)),
@@ -339,6 +361,7 @@ def _webpack_server_impl(ctx):
 
     runfiles = ctx.runfiles(
         files = [
+            node_package_manifest,
             package_manifest,
             runtime,
             shim,

--- a/webpack/server-runner.sh.tpl
+++ b/webpack/server-runner.sh.tpl
@@ -22,6 +22,7 @@ function abspath () {
 export COMPILATION_MODE=%{compilation_mode}
 export NODE_OPTIONS_APPEND="-r $(abspath "$RUNFILES_DIR"/%{runtime}/index.js) -r $(abspath "$RUNFILES_DIR"/%{shim}/index.js)"
 export JS_SOURCE_MAP=%{js_source_map}
+export NODE_PACKAGE_MANIFEST="$RUNFILES_DIR"/%{node_package_manifest}
 export WATCHPACK_POLLING=130929
 export WEBPACK_CONFIG="$RUNFILES_DIR"/%{config}
 export WEBPACK_DIGEST="$RUNFILES_DIR"/%{digest}


### PR DESCRIPTION
## Problem

`97e3e9b` (Use Yarn PnP for `nodejs_binary`) dropped the CommonJS package manifest and the `NODE_PACKAGE_MANIFEST` export from `nodejs/runner.sh.tpl`. `webpack/server/src/index.ts` still reads that variable, so **every `webpack_server` binary dies at startup**:

```
Error: Unsupported path type: undefined
    at NodePathFS.mapToBase (…webpack.server_bin.pnp.cjs:10109:11)
    at NodePathFS.readFileSync (…webpack.server_bin.pnp.cjs:8665:42)
    at Object.<anonymous> (external/rules_javascript+/webpack/server/src/index.js:17:61)
```

(`fs.readFileSync(undefined, "utf8")`, via PnP's patched `fs`.)

## Why the manifest is not vestigial

PnP resolves the dev server's own `require`s, so the obvious fix — deleting the manifest read — looked right. It isn't. The dev server *bundles* files out of the tool tree, and webpack resolves **their** imports from the filesystem, where PnP materializes nothing. Removing the fs-linker view instead produces:

```
ERROR in …/redo_npm_webpack_5.94.0/files/hot/emitter.js
Module not found: Error: Can't resolve 'events'
ERROR in …/redo_npm_pmmmwh_react-refresh-webpack-plugin_0.5.17/files/client/ReactRefreshEntry.js
Module not found: Error: Can't resolve 'core-js-pure/features/global-this'
```

and, before that, `webpack-dev-server`'s `isInstalled` `node_modules` walk fails, so it prompts to `yarn add -D webpack-cli`. (`webpack/runtime` only fakes `process.versions.pnp` for webpack's own `checkPackageExists`, not for the dev server's `isInstalled`.)

## Fix

`webpack_server` generates the manifest itself instead of borrowing `nodejs_binary`'s.

It needs the server binary's CommonJS graph **in the binary's own configuration** — a plain `cfg = "exec"` attribute would not match, because `nodejs_binary`'s `dep` goes through `nodejs_transition` (`//javascript:module = "node"`), and mismatched paths would make the manifest point at files that are not in runfiles. So `nodejs_binary` forwards its dep's `CjsInfo`, `WebpackInfo` carries it as `server_cjs`, and `_webpack_server_impl` runs `gen_manifest` over it with `to_rlocation_path` package paths — the same shape `nodejs_binary` used to emit. `webpack/server-runner.sh.tpl` exports `NODE_PACKAGE_MANIFEST` from it; the shim is unchanged.

## Verification

Against redo at the `4b6fe19` pin, carrying this as an `archive_override` patch:

- `bazel run //redo/shopify/extension:server` — starts, `webpack 5.94.0 compiled successfully`, no unresolved modules, serves `main.js` with HTTP 200 / 6,132,734 bytes.
- Every `webpack_server`, `webpack_bundle`, and `nodejs_binary` target in redo builds.

Before the fix, the same target crashed on `NODE_PACKAGE_MANIFEST` at startup.